### PR TITLE
Make transformations between global and region CRS work both ways

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,14 @@ EXPOSE 5000
 
 RUN mkdir /proj
 
-ADD https://download.osgeo.org/proj/proj-datumgrid-europe-latest.tar.gz /
-ADD https://download.osgeo.org/proj/proj-datumgrid-north-america-latest.tar.gz /
+ADD https://download.osgeo.org/proj/proj-datumgrid-europe-1.4.tar.gz /
+ADD https://download.osgeo.org/proj/proj-datumgrid-north-america-1.2.tar.gz /
 
-RUN tar -zxvf /proj-datumgrid-europe-latest.tar.gz -C /proj
-RUN tar -zxvf /proj-datumgrid-north-america-latest.tar.gz -C /proj
+RUN tar -zxvf /proj-datumgrid-europe-1.4.tar.gz -C /proj
+RUN tar -zxvf /proj-datumgrid-north-america-1.2.tar.gz -C /proj
 
-RUN rm /proj-datumgrid-europe-latest.tar.gz
-RUN rm /proj-datumgrid-north-america-latest.tar.gz
+RUN rm /proj-datumgrid-europe-1.4.tar.gz
+RUN rm /proj-datumgrid-north-america-1.2.tar.gz
 
 COPY /webproj /webproj/webproj
 COPY /tests /webproj/tests

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -176,3 +176,35 @@ class TestAPI(WebProjTest):
             "v4": None,
         }
         self.assert_coordinate(api_entry, expected)
+
+    def test_transformation_between_global_and_regional_crs(self):
+        """
+        Transformation between WGS84 and ETRS89/GR96 should be
+        possible both ways. Test the logic that determines if two
+        CRS's are compatible.
+        """
+        # first test the case from a global CRS to a regional CRS
+        api_entry = (
+            "/v1.0/trans/EPSG:4326/EPSG:25832/55.68950140789923,12.58696909994519"
+        )
+        expected = {"v1": 725448.0, "v2": 6177354.999999999, "v3": None, "v4": None}
+        self.assert_coordinate(api_entry, expected)
+
+        # then test the reverse case from regional to global
+        api_entry = "/v1.0/trans/EPSG:25832/EPSG:4258/725448.0,6177355.0"
+        expected = {
+            "v1": 55.689501407899236,
+            "v2": 12.58696909994519,
+            "v3": None,
+            "v4": None,
+        }
+        self.assert_coordinate(api_entry, expected, tolerance=1e-9)
+
+        # test some failing cases DK -> GL
+        api_entry = "v1.0/trans/EPSG:4258/EPSG:4909/55.0,12.0"
+        expected = {"message": "CRS's are not compatible across countries"}
+        self.assert_result(api_entry, expected)
+
+        api_entry = "v1.0/trans/EPSG:4909/EPSG:4258/75.0,-50.0"
+        expected = {"message": "CRS's are not compatible across countries"}
+        self.assert_result(api_entry, expected)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,13 +8,31 @@ from webproj import api
 class WebProjTest(unittest.TestCase):
     def assert_result(self, entry, expected_json_output):
         """
-        Check that a given API resource return the expected result
+        Check that a given API resource return the expected result.
         """
         response = self.app.get(entry)
         self.assertEqual(
             json.loads(response.get_data().decode(sys.getdefaultencoding())),
             expected_json_output,
         )
+
+    def assert_coordinate(self, entry, expected_json_output, tolerance=1e-6):
+        """
+        Check that a returned coordinate matches the expected result
+        within a pre-determined tolerance
+        """
+        response = self.app.get(entry)
+        result = json.loads(response.get_data().decode(sys.getdefaultencoding()))
+        for key in expected_json_output.keys():
+            if not key in result.keys():
+                raise AssertionError
+
+        for key, value in result.items():
+            expected_value = expected_json_output[key]
+            if value is  None and expected_value is None:
+                continue
+            if abs(value - expected_value) > tolerance:
+                raise AssertionError
 
 
 class TestAPI(WebProjTest):
@@ -72,7 +90,7 @@ class TestAPI(WebProjTest):
             "v3": None,
             "v4": None,
         }
-        self.assert_result(api_entry, expected)
+        self.assert_coordinate(api_entry, expected)
 
     def test_trans_3d(self):
         """
@@ -85,7 +103,7 @@ class TestAPI(WebProjTest):
             "v3": 30.0,
             "v4": None,
         }
-        self.assert_result(api_entry, expected)
+        self.assert_coordinate(api_entry, expected)
 
     def test_trans_4d(self):
         """
@@ -98,7 +116,7 @@ class TestAPI(WebProjTest):
             "v3": 30.0,
             "v4": 2010.5,
         }
-        self.assert_result(api_entry, expected)
+        self.assert_coordinate(api_entry, expected)
 
     def test_sys34(self):
         """
@@ -112,7 +130,7 @@ class TestAPI(WebProjTest):
             "v3": None,
             "v4": None,
         }
-        self.assert_result(api_entry_fwd, exp_fwd)
+        self.assert_coordinate(api_entry_fwd, exp_fwd)
 
         api_entry_inv = "v1.0/trans/EPSG:25832/DK:S34J/500000.0,6205000.0"
         exp_inv = {
@@ -121,9 +139,9 @@ class TestAPI(WebProjTest):
             "v3": None,
             "v4": None,
         }
-        self.assert_result(api_entry_inv, exp_inv)
+        self.assert_coordinate(api_entry_inv, exp_inv)
 
-        apy_entry_js = (
+        api_entry_js = (
             "v1.0/trans/DK:S34J/DK:S34S/138040.74248674404,63621.728972878314"
         )
         exp_js = {
@@ -132,6 +150,7 @@ class TestAPI(WebProjTest):
             "v3": None,
             "v4": None,
         }
+        self.assert_coordinate(api_entry_js, exp_js)
 
     def test_transformation_outside_crs_area_of_use(self):
         """
@@ -156,4 +175,4 @@ class TestAPI(WebProjTest):
             "v3": None,
             "v4": None,
         }
-        self.assert_result(api_entry, expected)
+        self.assert_coordinate(api_entry, expected)

--- a/webproj/api.py
+++ b/webproj/api.py
@@ -68,7 +68,7 @@ class OptimusPrime:
 
         src_region = CRS_LIST[src]["country"]
         dst_region = CRS_LIST[dst]["country"]
-        if src_region not in (dst_region, "Global"):
+        if src_region != dst_region and "Global" not in (src_region, dst_region):
             raise ValueError("CRS's are not compatible across countries")
 
         # determine region of transformation
@@ -225,7 +225,6 @@ class Transformation3D(Resource):
         "v3": "3rd coordinate component",
     }
 
-
     @api.doc(params=doc)
     def get(self, src, dst, v1, v2, v3):
         """
@@ -268,7 +267,8 @@ api.add_resource(EndPoint, "/")
 api.add_resource(CRSIndex, "/v1.0/crs/")
 api.add_resource(CRS, "/v1.0/crs/<string:crs>")
 api.add_resource(
-    Transformation2D, "/v1.0/trans/<string:src>/<string:dst>/<float(signed=True):v1>,<float(signed=True):v2>"
+    Transformation2D,
+    "/v1.0/trans/<string:src>/<string:dst>/<float(signed=True):v1>,<float(signed=True):v2>",
 )
 api.add_resource(
     Transformation3D,


### PR DESCRIPTION
Transformations from a regional CRS to a global CRS resulted in a
erronous error message being displayed, stating that the transformation
was invalid. The same transformation in the opposite direction was okay.
This commit fixes the faulty logic that checks if two CRS's are
compatible or not.

Fixes #15