### PR TITLE
Allow use of integer coordinates in trans/ routes

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,7 +29,7 @@ class WebProjTest(unittest.TestCase):
 
         for key, value in result.items():
             expected_value = expected_json_output[key]
-            if value is  None and expected_value is None:
+            if value is None and expected_value is None:
                 continue
             if abs(value - expected_value) > tolerance:
                 raise AssertionError
@@ -208,3 +208,52 @@ class TestAPI(WebProjTest):
         api_entry = "v1.0/trans/EPSG:4909/EPSG:4258/75.0,-50.0"
         expected = {"message": "CRS's are not compatible across countries"}
         self.assert_result(api_entry, expected)
+
+    def test_integer_coordinates(self):
+        """
+        Test the 'number' Werkzeug converter for parsing coordinates in routes
+        """
+        api_entry = "/v1.0/trans/EPSG:4258/EPSG:25832/56,12"
+        expected = {
+            "v1": 687071.4391094431,
+            "v2": 6210141.326748009,
+            "v3": None,
+            "v4": None,
+        }
+        self.assert_coordinate(api_entry, expected)
+
+        api_entry = "/v1.0/trans/EPSG:4258/EPSG:25832/56.,12."
+        expected = {
+            "v1": 687071.4391094431,
+            "v2": 6210141.326748009,
+            "v3": None,
+            "v4": None,
+        }
+        self.assert_coordinate(api_entry, expected)
+
+        api_entry = "/v1.0/trans/EPSG:4258/EPSG:25832/56.0,12.0"
+        expected = {
+            "v1": 687071.4391094431,
+            "v2": 6210141.326748009,
+            "v3": None,
+            "v4": None,
+        }
+        self.assert_coordinate(api_entry, expected)
+
+        api_entry = "/v1.0/trans/EPSG:4258/EPSG:25832/56,12,0"
+        expected = {
+            "v1": 687071.4391094431,
+            "v2": 6210141.326748009,
+            "v3": 0.0,
+            "v4": None,
+        }
+        self.assert_coordinate(api_entry, expected)
+
+        api_entry = "/v1.0/trans/EPSG:4258/EPSG:25832/56,12,0,2020"
+        expected = {
+            "v1": 687071.4391094431,
+            "v2": 6210141.326748009,
+            "v3": 0.0,
+            "v4": 2020,
+        }
+        self.assert_coordinate(api_entry, expected)

--- a/webproj/api.py
+++ b/webproj/api.py
@@ -8,12 +8,16 @@ from flask_restplus import Api, Resource, fields, abort
 import pyproj
 from pyproj.transformer import Transformer, AreaOfInterest
 
+from webproj.utils import IntFloatConverter
+
 version = "0.1"
 
 if "WEBPROJ_LIB" in os.environ:
     pyproj.datadir.append_data_dir(os.environ["WEBPROJ_LIB"])
 
+# Set up the app
 app = Flask(__name__)
+app.url_map.converters["number"] = IntFloatConverter
 CORS(app)
 
 api = Api(app, version=version, title="WEBPROJ")
@@ -267,14 +271,13 @@ api.add_resource(EndPoint, "/")
 api.add_resource(CRSIndex, "/v1.0/crs/")
 api.add_resource(CRS, "/v1.0/crs/<string:crs>")
 api.add_resource(
-    Transformation2D,
-    "/v1.0/trans/<string:src>/<string:dst>/<float(signed=True):v1>,<float(signed=True):v2>",
+    Transformation2D, "/v1.0/trans/<string:src>/<string:dst>/<number:v1>,<number:v2>"
 )
 api.add_resource(
     Transformation3D,
-    "/v1.0/trans/<string:src>/<string:dst>/<float(signed=True):v1>,<float(signed=True):v2>,<float(signed=True):v3>",
+    "/v1.0/trans/<string:src>/<string:dst>/<number:v1>,<number:v2>,<number:v3>",
 )
 api.add_resource(
     Transformation4D,
-    "/v1.0/trans/<string:src>/<string:dst>/<float(signed=True):v1>,<float(signed=True):v2>,<float(signed=True):v3>,<float(signed=True):v4>",
+    "/v1.0/trans/<string:src>/<string:dst>/<number:v1>,<number:v2>,<number:v3>,<number:v4>",
 )

--- a/webproj/utils.py
+++ b/webproj/utils.py
@@ -1,0 +1,18 @@
+from werkzeug.routing import BaseConverter
+
+
+class IntFloatConverter(BaseConverter):
+    """
+    Creates a new datatype for use in flask routes.
+
+    Shamelessly stolen from
+    https://github.com/pallets/werkzeug/issues/1645#issuecomment-532829939
+    """
+
+    regex = r"-?(?:\d+(?:\.(?:\d+)?)?|\.\d+)"
+
+    def to_python(self, value):
+        try:
+            return int(value)
+        except ValueError:
+            return float(value)


### PR DESCRIPTION
Previously only floats following the format <number>.<number> were
allowed. This is painfull when entering coordinates by hand. Fixed by
adding a custom input converter to the app.